### PR TITLE
appveyor: config and scripts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,136 @@
+# Appveyor configuration template for Rust
+# https://github.com/starkat99/appveyor-rust
+
+## Operating System (VM environment) ##
+
+# Rust needs at least Visual Studio 2013 Appveyor OS for MSVC targets.
+os: Visual Studio 2015
+image: Visual Studio 2015
+
+max_jobs: -1
+
+## Build Matrix ##
+
+# This configuration will setup a build for each channel & target combination (12 windows
+# combinations in all).
+#
+# There are 3 channels: stable, beta, and nightly.
+#
+# Alternatively, the full version may be specified for the channel to build using that specific
+# version (e.g. channel: 1.5.0)
+#
+# The values for target are the set of windows Rust build targets. Each value is of the form
+#
+# ARCH-pc-windows-TOOLCHAIN
+#
+# Where ARCH is the target architecture, either x86_64 or i686, and TOOLCHAIN is the linker
+# toolchain to use, either msvc or gnu. See https://www.rust-lang.org/downloads.html#win-foot for
+# a description of the toolchain differences.
+#
+# Comment out channel/target combos you do not wish to build in CI.
+environment:
+  matrix:
+### Stable Toolchains ###
+  # Stable 64-bit MSVC
+    - channel: stable
+      target: x86_64-pc-windows-msvc
+  # Stable 64-bit GNU
+  # - channel: stable
+  #   target: x86_64-pc-windows-gnu
+  # Stable 32-bit MSVC
+    - channel: stable
+      target: i686-pc-windows-msvc
+  # Stable 32-bit GNU
+  # - channel: stable
+  #   target: i686-pc-windows-gnu
+### Beta Toolchains ###
+  # Beta 64-bit MSVC
+    - channel: beta
+      target: x86_64-pc-windows-msvc
+  # Beta 64-bit GNU
+  # - channel: beta
+  #   target: x86_64-pc-windows-gnu
+  # Beta 32-bit MSVC
+    - channel: beta
+      target: i686-pc-windows-msvc
+  # Beta 32-bit GNU
+  # - channel: beta
+  #   target: i686-pc-windows-gnu
+### Nightly Toolchains ###
+  # Nightly 64-bit MSVC
+    - channel: nightly
+      target: x86_64-pc-windows-msvc
+  # Nightly 64-bit GNU
+  # - channel: nightly
+  #   target: x86_64-pc-windows-gnu
+  # Nightly 32-bit MSVC
+    - channel: nightly
+      target: i686-pc-windows-msvc
+  # Nightly 32-bit GNU
+  # - channel: nightly
+  #   target: i686-pc-windows-gnu
+
+# For now, we only care about release builds
+configuration:
+  - release
+
+# We will never care about x86, may add ARM in the future
+platform:
+  - x64
+  - x86
+
+### Allowed failures ###
+
+# See Appveyor documentation for specific details. In short, place any channel or targets you wish
+# to allow build failures on (usually nightly at least is a wise choice). This will prevent a build
+# or test failure in the matching channels/targets from failing the entire build.
+matrix:
+  allow_failures:
+    - channel: nightly
+    - channel: beta
+    - platform: x86
+      target:
+        - x86_64-pc-windows-msvc
+        - x86_64-pc-windows-gnu
+    - platform: x64
+      target:
+        - i686-pc-windows-msvc
+        - i686-pc-windows-gnu
+
+## Install Script ##
+
+# This is the most important part of the Appveyor configuration. This installs the version of Rust
+# specified by the 'channel' and 'target' environment variables from the build matrix. By default,
+# Rust will be installed to C:\Rust for easy usage, but this path can be overridden by setting the
+# RUST_INSTALL_DIR environment variable. The URL to download rust distributions defaults to
+# https://static.rust-lang.org/dist/ but can overridden by setting the RUST_DOWNLOAD_URL environment
+# variable.
+#
+# For simple configurations, instead of using the build matrix, you can override the channel and
+# target environment variables with the -channel and -target script arguments.
+#
+# If no channel or target arguments or environment variables are specified, will default to stable
+# channel and x86_64-pc-windows-msvc target.
+#
+# The file appveyor_rust_install.ps1 must exist in the root directory of the repository.
+install:
+- ps: .\.appveyor\platform_check.ps1
+- ps: .\.appveyor\install_dependencies.ps1
+- ps: .\.appveyor\install_rust.ps1
+
+# Alternative install command for simple configurations without build matrix (uncomment line and
+# comment above line):
+#- ps: .\appveyor_rust_install.ps1 -channel stable -target x86_64-pc-windows-msvc
+
+## Build Script ##
+
+# 'cargo test' takes care of building for us, so disable Appveyor's build stage. This prevents
+# the "directory does not contain a project or solution file" error.
+build: false
+
+# Uses 'cargo test' to run tests. Alternatively, the project may call compiled programs directly or
+# perform other testing commands. Rust will automatically be placed in the PATH environment
+# variable.
+test_script:
+# Using cmd to avoid PowerShell's ugly handling of cargo's output
+- cmd: .\.appveyor\test_script.cmd

--- a/.appveyor/install_dependencies.ps1
+++ b/.appveyor/install_dependencies.ps1
@@ -1,0 +1,44 @@
+# Current sqlite version in nuget repository.
+$openssl_version = "1.0.2.6"
+
+# Download the latest nuget
+appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+# Use it to install openssl
+.\nuget install openssl.v120.dyn-rt.static -version $openssl_version
+
+if ($env:target.Contains("i686")) {
+    $platform_path = "\Win32\v120"
+} else {
+    $platform_path = "\x64\v120"
+}
+
+if ($env:CONFIGURATION.Contains("release")) {
+    $build_type_path = "\Release"
+} elseif ($env:CONFIGURATION.Contains("debug")) {
+    $build_type_path = "\Debug"
+}
+
+# Set the proper environment variables for the build
+# AppVeyor env variables: https://www.appveyor.com/docs/environment-variables/
+$openssl_dir = $env:APPVEYOR_BUILD_FOLDER + "\openssl.v120.dyn-rt.static." + $openssl_version + "\build\native"
+$openssl_lib = $openssl_dir + "\lib"
+
+# Put it all together and set the environment variable
+$OPENSSL_INCLUDES = $openssl_dir + "\include"
+$OPENSSL_LIB_DIR = $openssl_lib + $platform_path + $build_type_path
+
+$old_path = $OPENSSL_LIB_DIR + "\libeay32.lib"
+$new_path = $OPENSSL_LIB_DIR + "\eay32.lib"
+cp  $old_path $new_path
+ls $OPENSSL_INCLUDES
+ls $OPENSSL_LIB_DIR
+
+if ($env:target.Contains("msvc")) {
+     [Environment]::SetEnvironmentVariable("LIB", $OPENSSL_LIB_DIR, "Process")
+     [Environment]::SetEnvironmentVariable("INCLUDE", $OPENSSL_INCLUDES, "Process")
+}
+if ($env:target.Contains("gnu")) {
+     [Environment]::SetEnvironmentVariable("LIBRARY_PATH", $OPENSSL_LIB_DIR, "Process")
+     [Environment]::SetEnvironmentVariable("C_INCLUDE_PATH", $OPENSSL_INCLUDES, "Process")
+}
+

--- a/.appveyor/install_rust.ps1
+++ b/.appveyor/install_rust.ps1
@@ -1,0 +1,72 @@
+##### Appveyor Rust Install Script #####
+
+# https://github.com/starkat99/appveyor-rust
+
+# This is the most important part of the Appveyor configuration. This installs the version of Rust
+# specified by the "channel" and "target" environment variables from the build matrix. By default,
+# Rust will be installed to C:\Rust for easy usage, but this path can be overridden by setting the
+# RUST_INSTALL_DIR environment variable. The URL to download rust distributions defaults to
+# https://static.rust-lang.org/dist/ but can overridden by setting the RUST_DOWNLOAD_URL environment
+# variable.
+#
+# For simple configurations, instead of using the build matrix, you can override the channel and
+# target environment variables with the --channel and --target script arguments.
+#
+# If no channel or target arguments or environment variables are specified, will default to stable
+# channel and x86_64-pc-windows-msvc target.
+
+param([string]$channel=${env:channel}, [string]$target=${env:target})
+
+# Initialize our parameters from arguments and environment variables, falling back to defaults
+if (!$channel) {
+    $channel = "stable"
+}
+if (!$target) {
+    $target = "x86_64-pc-windows-msvc"
+}
+
+$downloadUrl = "https://static.rust-lang.org/dist/"
+if ($env:RUST_DOWNLOAD_URL) {
+    $downloadUrl = $env:RUST_DOWNLOAD_URL
+}
+
+$installDir = "C:\Rust"
+if ($env:RUST_INSTALL_DIR) {
+    $installUrl = $env:RUST_INSTALL_DIR
+}
+
+if ($channel -eq "stable") {
+    # Download manifest so we can find actual filename of installer to download. Needed for stable.
+    echo "Downloading $channel channel manifest"
+    $manifest = "${env:Temp}\channel-rust-${channel}"
+    Start-FileDownload "${downloadUrl}channel-rust-${channel}" -FileName "$manifest"
+
+    # Search the manifest lines for the correct filename based on target
+    $match = Get-Content "$manifest" | Select-String -pattern "${target}.exe" -simplematch
+
+    if (!$match -or !$match.line) {
+        throw "Could not find $target in $channel channel manifest"
+    }
+
+    $installer = $match.line
+} else {
+    # Otherwise download the file specified by channel directly.
+    $installer = "rust-${channel}-${target}.exe"
+}
+
+# Download installer
+echo "Downloading ${downloadUrl}$installer"
+Start-FileDownload "${downloadUrl}$installer" -FileName "${env:Temp}\$installer"
+
+# Execute installer and wait for it to finish
+echo "Installing $installer to $installDir"
+&"${env:Temp}\$installer" /VERYSILENT /NORESTART /DIR="$installDir" | Write-Output
+
+# Add Rust to the path.
+$env:Path += ";${installDir}\bin;C:\MinGW\bin"
+
+echo "Installation of $channel Rust $target completed"
+
+# Test and display installed version information for rustc and cargo
+rustc -V
+cargo -V

--- a/.appveyor/platform_check.ps1
+++ b/.appveyor/platform_check.ps1
@@ -1,0 +1,21 @@
+if ($env:target.Contains("x86_64")) {
+    Write-Host("Platform: {0}" -f $env:platform)
+    if ($env:platform.Contains("x86")) {
+        Write-Host("Skipping cross compilation")
+        exit -1
+    }
+}
+        
+if ($env:target.Contains("i686")) {
+    if ($env:platform.Contains("x64")) {
+        Write-Host("Skipping cross compilation")
+        exit -1
+    }
+}
+
+if ($env:platform.Contains("x64")) {
+    if ($env:target.Contains("gnu")) {
+        Write-Host("Skipping x64 GNU builds")
+        exit -1
+    }
+}

--- a/.appveyor/test_script.cmd
+++ b/.appveyor/test_script.cmd
@@ -1,0 +1,8 @@
+If /i "%CONFIGURATION%"=="release" (
+    SET cfg=--release
+) ELSE (
+    SET cfg
+)
+SET cfgcmd=cargo test --verbose %cfg%
+ECHO %cfgcmd%
+call %%cfgcmd%%


### PR DESCRIPTION
Skip cross compilation builds (autofail)
Skip GNU ABI on windows for now